### PR TITLE
code: add support for node-redis 2.6

### DIFF
--- a/shim.js
+++ b/shim.js
@@ -45,4 +45,13 @@ module.exports = function patchRedis(ns) {
       return send_command.apply(this, args);
     };
   });
+  shimmer.wrap(proto, 'internal_send_command', function (internal_send_command) {
+    return function wrapped(command_obj) {
+      if (command_obj && typeof command_obj.callback === 'function') {
+        command_obj.callback = ns.bind(command_obj.callback);
+      }
+
+      return internal_send_command.call(this, command_obj);
+    };
+  });
 };


### PR DESCRIPTION
`node-redis` changed the function name from `send_command` to `internal_send_command` and the function signature to accept a single object.

Fixes #6  
Fixes #8

`package.json` needs to be updated to reflect new version range. I'm not sure how to add tests since we need to install multiple versions of `node-redis` to test the new functionality.